### PR TITLE
feat: implement generic robot description override

### DIFF
--- a/teleop_xr/ik/loader.py
+++ b/teleop_xr/ik/loader.py
@@ -21,8 +21,8 @@ def load_robot_class(robot_spec: str | None = None) -> type[BaseRobot]:
     4. Otherwise, raise RobotLoadError.
 
     Robot Constructor Contract:
-    All robot classes must support the following constructor signature:
-    `def __init__(self, urdf_string: str | None = None, **kwargs)`
+    All robot classes should support optional initialization kwargs and implement
+    `BaseRobot.override_robot_description(...)` for runtime overrides.
 
     Args:
         robot_spec: The robot specification string or None.

--- a/teleop_xr/ik/robot.py
+++ b/teleop_xr/ik/robot.py
@@ -16,6 +16,49 @@ class BaseRobot(ABC):
     to compute kinematics and optimization costs.
     """
 
+    def __init__(self, robot_description_override: str | None = None) -> None:
+        self._robot_description_override = robot_description_override
+
+    @property
+    @abstractmethod
+    def robot_description(self) -> str:
+        """
+        Default robot description source.
+
+        Returns:
+            str: Either a filesystem path to a URDF file or a URDF XML string.
+        """
+        pass  # pragma: no cover
+
+    @property
+    def active_robot_description(self) -> str:
+        """Description currently used by the robot (override if present)."""
+        return self._robot_description_override or self.robot_description
+
+    def override_robot_description(self, robot_description: str | None) -> None:
+        """
+        Override the robot description and reinitialize URDF-dependent state.
+
+        Args:
+            robot_description: URDF file path or URDF XML string. Pass None to
+                clear the override and fall back to `robot_description`.
+        """
+        self._robot_description_override = robot_description
+        self.reinitialize_from_description()
+
+    def reinitialize_from_description(self) -> None:
+        """
+        Reinitialize URDF-dependent state from the active description.
+
+        Subclasses should override `_initialize_from_description` to rebuild
+        robot model state (kinematics, collision, link indices, etc.).
+        """
+        self._initialize_from_description(self.active_robot_description)
+
+    def _initialize_from_description(self, robot_description: str) -> None:
+        """Subclass hook for rebuilding URDF-dependent state."""
+        del robot_description
+
     @property
     def orientation(self) -> jaxlie.SO3:
         """

--- a/tests/test_controller_frames.py
+++ b/tests/test_controller_frames.py
@@ -18,7 +18,12 @@ from teleop_xr.messages import (
 
 class MockRobot(BaseRobot):
     def __init__(self, supported_frames={"left", "right", "head"}):
+        super().__init__()
         self._supported_frames = supported_frames
+
+    @property
+    def robot_description(self) -> str:
+        return "<robot name='mock'/>"
 
     @property
     def supported_frames(self):

--- a/tests/test_franka_robot.py
+++ b/tests/test_franka_robot.py
@@ -113,6 +113,22 @@ def test_franka_get_vis_config_none():
     assert robot.get_vis_config() is None
 
 
+def test_franka_override_robot_description(dummy_urdf_file, mock_ram):
+    mock_ram.get_resource.return_value = dummy_urdf_file
+    mock_ram.get_repo.return_value = dummy_urdf_file.parent
+
+    robot = FrankaRobot()
+    assert robot.get_vis_config() is not None
+
+    robot.override_robot_description(MINIMAL_FRANKA_URDF)
+    assert robot.get_vis_config() is None
+
+    robot.override_robot_description(None)
+    vis_config = robot.get_vis_config()
+    assert vis_config is not None
+    assert vis_config.urdf_path == str(dummy_urdf_file)
+
+
 def test_franka_init_error(tmp_path):
     with (
         patch("teleop_xr.ik.robots.franka.ram.get_resource") as mock_get,

--- a/tests/test_ik_api.py
+++ b/tests/test_ik_api.py
@@ -23,12 +23,17 @@ def test_base_robot_is_abc():
         "get_default_config",
         "build_costs",
         "actuated_joint_names",
+        "robot_description",
     }
     assert expected_methods.issubset(abstract_methods)
 
 
 def test_pyroki_solver_instantiation():
     class MockRobot(BaseRobot):
+        @property
+        def robot_description(self) -> str:
+            return "<robot name='mock'/>"
+
         def get_vis_config(self):
             return None
 
@@ -47,7 +52,9 @@ def test_pyroki_solver_instantiation():
             target_L: jaxlie.SE3 | None,
             target_R: jaxlie.SE3 | None,
             target_Head: jaxlie.SE3 | None,
+            q_current: jnp.ndarray | None = None,
         ) -> List[Any]:
+            del q_current
             return []
 
         @property
@@ -61,6 +68,10 @@ def test_pyroki_solver_instantiation():
 
 def test_ik_controller_instantiation():
     class MockRobot(BaseRobot):
+        @property
+        def robot_description(self) -> str:
+            return "<robot name='mock'/>"
+
         def get_vis_config(self):
             return None
 
@@ -74,7 +85,8 @@ def test_ik_controller_instantiation():
         def get_default_config(self) -> jnp.ndarray:
             return jnp.zeros(2)
 
-        def build_costs(self, target_L, target_R, target_Head):
+        def build_costs(self, target_L, target_R, target_Head, q_current=None):
+            del q_current
             return []
 
         @property
@@ -90,6 +102,10 @@ def test_ik_controller_instantiation():
 
 def test_ik_controller_with_filter():
     class MockRobot(BaseRobot):
+        @property
+        def robot_description(self) -> str:
+            return "<robot name='mock'/>"
+
         def get_vis_config(self):
             return None
 
@@ -103,7 +119,8 @@ def test_ik_controller_with_filter():
         def get_default_config(self) -> jnp.ndarray:
             return jnp.zeros(2)
 
-        def build_costs(self, target_L, target_R, target_Head):
+        def build_costs(self, target_L, target_R, target_Head, q_current=None):
+            del q_current
             return []
 
         @property

--- a/tests/test_ik_controller.py
+++ b/tests/test_ik_controller.py
@@ -18,6 +18,10 @@ from teleop_xr.messages import (
 
 
 class DummyRobot(BaseRobot):
+    @property
+    def robot_description(self) -> str:
+        return "<robot name='dummy'/>"
+
     def get_vis_config(self):
         return None
 
@@ -42,8 +46,11 @@ class DummyRobot(BaseRobot):
 
 class DummySolver(PyrokiSolver):
     def __init__(self, out: np.ndarray):
-        # We don't call super().__init__ because we don't want to trigger _warmup
         self.out = out
+        super().__init__(DummyRobot())
+
+    def _warmup(self) -> None:
+        return None
 
     def solve(self, target_L, target_R, target_Head, q_current):
         return jnp.asarray(self.out)

--- a/tests/test_robots.py
+++ b/tests/test_robots.py
@@ -49,6 +49,10 @@ H1_URDF = """
 
 class MockBaseRobot(BaseRobot):
     @property
+    def robot_description(self) -> str:
+        return "<robot name='mock'/>"
+
+    @property
     def actuated_joint_names(self):
         return ["j1"]
 
@@ -144,6 +148,10 @@ def test_h1_robot(tmp_path):
             q_current=q,
         )
         assert len(costs) > 0
+        assert robot.get_vis_config() is not None
+        robot.override_robot_description(H1_URDF)
+        assert robot.get_vis_config() is None
+        robot.override_robot_description(None)
         assert robot.get_vis_config() is not None
         robot.urdf_path = ""
         assert robot.get_vis_config() is None


### PR DESCRIPTION
## Summary
- Refactored `BaseRobot` to include a generic `robot_description` property and an `override_robot_description` method.
- Implemented `reinitialize_from_description` in `BaseRobot` and specific robot classes (`UnitreeH1Robot`, `FrankaRobot`, `TeaArmRobot`) to rebuild kinematics, collision models, and link indices when the description changes.
- Updated the ROS2 entry point to generically handle URDF overrides from topics or parameters.
- Updated all test suites and mocks to support the new robot description API.