### PR TITLE
ci: parallelize jobs and reduce redundant npm installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,6 @@ jobs:
   tests:
     name: Tests (pytest) on ${{ matrix.os }} (${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
-    needs: quality
     env:
       TELEOP_XR_SKIP_WEBXR_BUILD: "1"
     strategy:
@@ -84,7 +83,6 @@ jobs:
   build:
     name: Build Package (uv)
     runs-on: ubuntu-latest
-    needs: quality
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/typescript-ci.yml
+++ b/.github/workflows/typescript-ci.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  test:
-    name: Test & Coverage
+  test-lint-build:
+    name: Test, Lint & Build
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -59,48 +59,9 @@ jobs:
           path: webxr/coverage/
           if-no-files-found: warn
 
-  lint:
-    name: Lint TypeScript Code
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./webxr
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: webxr/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
-
       - name: Run linter
         run: npm run lint
         continue-on-error: true
-
-  build:
-    name: Build WebXR
-    runs-on: ubuntu-latest
-    needs: test
-    defaults:
-      run:
-        working-directory: ./webxr
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "npm"
-          cache-dependency-path: webxr/package-lock.json
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary

- Combine TypeScript test/lint/build into single job to reuse node_modules
- Remove blocking dependency between tests/build and quality job
- Estimated 3-5 min CI time savings per run