### PR TITLE
docs: add dora-rs interface guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The demo supports two operation modes:
 ## 📖 Documentation
 
 For detailed guides on integrating TeleopXR into your own projects, including
-the **Generic Python API** and **ROS2 Interface**, visit the official
-[documentation site](https://qrafty-ai.github.io/teleop_xr/generic/).
+the **Generic Python API**, **ROS2 Interface**, and **dora-rs Interface**,
+visit the official [documentation site](https://qrafty-ai.github.io/teleop_xr/generic/).
 
 ## Development
 

--- a/docs/dora.md
+++ b/docs/dora.md
@@ -1,0 +1,20 @@
+# dora-rs Interface
+
+TeleopXR can be integrated into [dora-rs](https://dora-rs.ai/) using the
+dedicated node available in the dora-hub.
+
+## Dora TeleopXR Node
+
+The official dora-rs integration provides a high-performance node that bridges
+WebXR teleoperation data into the dora-rs ecosystem.
+
+👉 **[dora-teleop-xr README](https://github.com/dora-rs/dora-hub/tree/main/node-hub/dora-teleop-xr)**
+
+The integration includes:
+
+- **XR State Streaming**: Seamlessly stream headset and controller poses into
+  your dora-rs graph.
+- **WebSocket Gateway**: High-performance bridging between WebXR clients and
+  dora-rs nodes.
+- **Configuration**: Easy setup via dora-rs YAML descriptors.
+- **Low Latency**: Optimized for real-time teleoperation with minimal overhead.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ nav:
   - Interfaces:
     - Generic Python API: generic.md
     - ROS2 Interface: ros2.md
+    - dora-rs Interface: dora.md
     - Custom Robots:
         - Setup: custom_robots.md
         - Sphere Collision: sphere_collision.md


### PR DESCRIPTION
## Summary
- Added a dedicated documentation page for the `dora-rs` interface.
- Updated `mkdocs.yml` navigation to include the new Dora interface guide.
- Linked to the official `dora-teleop-xr` README in the dora-hub.
- Updated root and docs READMEs to reference the new interface.