### PR TITLE
fix: unblock Windows pytest by removing invalid f-string backslash expression

### DIFF
--- a/teleop_xr/ram.py
+++ b/teleop_xr/ram.py
@@ -154,7 +154,8 @@ def _replace_relative_mesh_paths(urdf_content: str, base_dir: Path) -> str:
             return match.group(0)
 
         if re.match(r"^[A-Za-z]:[\\/]", raw_path):
-            return f"filename={quote}{raw_path.replace('\\\\', '/')}{quote}"
+            normalized_raw_path = raw_path.replace("\\", "/")
+            return f"filename={quote}{normalized_raw_path}{quote}"
 
         path_obj = Path(raw_path)
         if path_obj.is_absolute():


### PR DESCRIPTION
## Summary
- fix `teleop_xr/ram.py` Windows-drive path handling by moving `raw_path.replace("\\", "/")` out of the f-string expression
- this prevents Python from raising `SyntaxError: f-string expression part cannot include a backslash` during import/collection on Windows
- unblocks RAM-related pytest collection that was failing in CI run `22401967092`

## Root Cause
Python rejects backslashes inside f-string expression blocks. `raw_path.replace('\\', '/')` inside the f-string in `teleop_xr/ram.py` triggered import-time syntax errors on Windows jobs.

## Validation
- `uv run pytest tests/test_ram.py tests/test_ram_coverage.py tests/test_ram_from_string.py tests/test_ram_local.py tests/test_ram_windows_paths.py`
- `uv run python -m py_compile teleop_xr/ram.py`

## Reference
- Failing run: https://github.com/qrafty-ai/teleop_xr/actions/runs/22401967092/job/64850843053