### PR TITLE
fix(webxr): disable default thumbstick locomotion

### DIFF
--- a/webxr/src/xr/index.ts
+++ b/webxr/src/xr/index.ts
@@ -104,7 +104,7 @@ export const initWorld = async (
 			},
 		},
 		features: {
-			locomotion: true, // Enable locomotion to ensure Player rig is initialized
+			locomotion: false,
 			grabbing: true,
 			physics: false,
 			sceneUnderstanding: true,


### PR DESCRIPTION
## Summary
- disable the built-in WebXR locomotion feature so neither thumbstick triggers default movement
- leave left and right thumbstick axes unbound for future user customization
- keep the existing controller input forwarding path intact for teleop data
